### PR TITLE
ロングタップ時間を変更

### DIFF
--- a/app/src/main/java/jp/sabiz/kukan/common/LongTouchEventDetector.kt
+++ b/app/src/main/java/jp/sabiz/kukan/common/LongTouchEventDetector.kt
@@ -1,0 +1,56 @@
+package jp.sabiz.kukan.common
+
+import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.View
+import android.view.View.OnTouchListener
+import androidx.core.os.postDelayed
+
+class LongTouchEventDetector(private val longTouchTimeMillis:Long, private val listener: OnLongTouchEventListener): OnTouchListener {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var isLongTapStarted = false
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouch(v: View?, event: MotionEvent?): Boolean {
+        event?:return false
+        when(event.action.and(MotionEvent.ACTION_MASK)){
+            MotionEvent.ACTION_DOWN -> {
+                handler.removeCallbacksAndMessages(null)
+                if (isLongTapStarted) {
+                    handler.post {
+                        listener.onLongTouchCanceled()
+                    }
+                }
+                handler.post {
+                    listener.onLongTouchDown()
+                }
+                isLongTapStarted = true
+                handler.postDelayed(longTouchTimeMillis) {
+                    isLongTapStarted = false
+                    listener.onLongTouchUp()
+                }
+                return true
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                handler.removeCallbacksAndMessages(null)
+                if (isLongTapStarted) {
+                    handler.post {
+                        isLongTapStarted = false
+                        listener.onLongTouchCanceled()
+                    }
+                }
+                return true
+            }
+        }
+        return false
+    }
+
+    interface OnLongTouchEventListener {
+        fun onLongTouchDown()
+        fun onLongTouchCanceled()
+        fun onLongTouchUp()
+    }
+}

--- a/app/src/main/java/jp/sabiz/kukan/ui/KukanFragment.kt
+++ b/app/src/main/java/jp/sabiz/kukan/ui/KukanFragment.kt
@@ -1,13 +1,17 @@
 package jp.sabiz.kukan.ui
 
+import android.animation.ObjectAnimator
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import jp.sabiz.kukan.R
 import jp.sabiz.kukan.common.KukanState
 import jp.sabiz.kukan.common.PermissionChecker
@@ -32,6 +36,7 @@ class KukanFragment : Fragment() {
         kukanViewModel.loadDb()
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -39,6 +44,8 @@ class KukanFragment : Fragment() {
         _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_kukan, container, false)
         _binding.viewModel = kukanViewModel
         _binding.lifecycleOwner = this
+        val progress:ProgressBar = _binding.main.requireViewById(R.id.progress_on_off)
+        progress.setOnTouchListener(kukanViewModel.longTouchEventDetector)
         return _binding.main
     }
 

--- a/app/src/main/res/drawable/bg_on_off_progress.xml
+++ b/app/src/main/res/drawable/bg_on_off_progress.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape
+            android:shape="ring"
+            android:innerRadiusRatio="3"
+            android:thickness="8dp"
+            android:useLevel="false">
+            <solid android:color="@color/lcd_color_off" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/fg_on_off_progress.xml
+++ b/app/src/main/res/drawable/fg_on_off_progress.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:gravity="center"
+        android:drawable="@drawable/on_off"/>
+    <item>
+        <rotate
+        android:fromDegrees="270"
+        android:toDegrees="270">
+        <shape
+            android:innerRadiusRatio="3"
+            android:shape="ring"
+            android:thickness="8dp"
+            android:useLevel="true"><!-- this line fixes the issue for lollipop api 21 -->
+            <solid
+                android:color="@color/lcd_color"/>
+        </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/lcd_0.xml
+++ b/app/src/main/res/drawable/lcd_0.xml
@@ -7,6 +7,6 @@
       android:pathData="M0,0L0,0.08L15,15.08L15,15L84.95,15L99.95,0ZM100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM0,3.61l0,56.28l8.23,12.86 6.77,-10.27L15,18.61ZM0,85.22c0,-56.82 0,-28.41 0,0zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74ZM8.2,77.34 L0,89.76L0,146.29L15,131.29L15,87.98ZM85,134.78l0,0.22L15,135l0,-0.17L0,149.83l0,0.17l100,0l0,-0.22z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_1.xml
+++ b/app/src/main/res/drawable/lcd_1.xml
@@ -7,6 +7,6 @@
       android:pathData="M100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74Z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_2.xml
+++ b/app/src/main/res/drawable/lcd_2.xml
@@ -7,6 +7,6 @@
       android:pathData="M0,0L0,0.08L15,15.08L15,15L84.95,15L99.95,0ZM100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM0,85.22c0,-56.82 0,-28.41 0,0zM15.02,67 L9.7,75.06 15,83.34l0,-0.34L85,83l0,0.19l5.26,-8.22 -5.26,-7.97zM8.2,77.34 L0,89.76L0,146.29L15,131.29L15,87.98ZM85,134.78l0,0.22L15,135l0,-0.17L0,149.83l0,0.17l100,0l0,-0.22z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_3.xml
+++ b/app/src/main/res/drawable/lcd_3.xml
@@ -7,6 +7,6 @@
       android:pathData="M0,0L0,0.08L15,15.08L15,15L84.95,15L99.95,0ZM100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM15.02,67l-5.31,8.06 5.3,8.28l0,-0.34L85,83l0,0.19l5.26,-8.22 -5.26,-7.97zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74ZM85,134.78l0,0.22L15,135l0,-0.17L0,149.83l0,0.17l100,0l0,-0.22z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_4.xml
+++ b/app/src/main/res/drawable/lcd_4.xml
@@ -7,6 +7,6 @@
       android:pathData="M100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM0,3.61l0,56.28l8.23,12.86 6.77,-10.27L15,18.61ZM15.02,67 L9.7,75.06 15,83.34l0,-0.34L85,83l0,0.19l5.26,-8.22 -5.26,-7.97zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74Z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_5.xml
+++ b/app/src/main/res/drawable/lcd_5.xml
@@ -7,6 +7,6 @@
       android:pathData="M0,0L0,0.08L15,15.08L15,15L84.95,15L99.95,0ZM0,3.61l0,56.28l8.23,12.86 6.77,-10.27L15,18.61ZM15.02,67 L9.7,75.06 15,83.34l0,-0.34L85,83l0,0.19l5.26,-8.22 -5.26,-7.97zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74ZM85,134.78l0,0.22L15,135l0,-0.17L0,149.83l0,0.17l100,0l0,-0.22z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_6.xml
+++ b/app/src/main/res/drawable/lcd_6.xml
@@ -7,6 +7,6 @@
       android:pathData="m0,3.61l0,56.28l8.23,12.86 6.77,-10.27L15,18.61ZM0,85.22c0,-56.82 0,-28.41 0,0zM15.02,67 L9.7,75.06 15,83.34l0,-0.34L85,83l0,0.19l5.26,-8.22 -5.26,-7.97zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74ZM8.2,77.34 L0,89.76L0,146.29L15,131.29L15,87.98ZM85,134.78l0,0.22L15,135l0,-0.17L0,149.83l0,0.17l100,0l0,-0.22z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_7.xml
+++ b/app/src/main/res/drawable/lcd_7.xml
@@ -7,6 +7,6 @@
       android:pathData="M0,0L0,0.08L15,15.08L15,15L84.95,15L99.95,0ZM100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74Z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_8.xml
+++ b/app/src/main/res/drawable/lcd_8.xml
@@ -7,6 +7,6 @@
       android:pathData="M0,0L0,0.08L15,15.08L15,15L84.95,15L99.95,0ZM100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM0,3.61l0,56.28l8.23,12.86 6.77,-10.27L15,18.61ZM0,85.22c0,-56.82 0,-28.41 0,0zM15.02,67 L9.7,75.06 15,83.34l0,-0.34L85,83l0,0.19l5.26,-8.22 -5.26,-7.97zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74ZM8.2,77.34 L0,89.76L0,146.29L15,131.29L15,87.98ZM85,134.78l0,0.22L15,135l0,-0.17L0,149.83l0,0.17l100,0l0,-0.22z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/lcd_9.xml
+++ b/app/src/main/res/drawable/lcd_9.xml
@@ -7,6 +7,6 @@
       android:pathData="M0,0L0,0.08L15,15.08L15,15L84.95,15L99.95,0ZM100,3.49 L85,18.49L85,62.46l6.73,10.2 8.27,-12.92zM0,3.61l0,56.28l8.23,12.86 6.77,-10.27L15,18.61ZM15.02,67 L9.7,75.06 15,83.34l0,-0.34L85,83l0,0.19l5.26,-8.22 -5.26,-7.97zM91.76,77.26 L85,87.83l0,43.42l15,15L100,89.74Z"
       android:strokeLineJoin="round"
       android:strokeWidth="6.49"
-      android:fillColor="#292929"
+      android:fillColor="@color/lcd_color_off"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/on_off.xml
+++ b/app/src/main/res/drawable/on_off.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="@color/colorOnPrimary"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,3h-2v10h2L13,3zM17.83,5.17l-1.42,1.42C17.99,7.86 19,9.81 19,12c0,3.87 -3.13,7 -7,7s-7,-3.13 -7,-7c0,-2.19 1.01,-4.14 2.58,-5.42L6.17,5.17C4.23,6.82 3,9.26 3,12c0,4.97 4.03,9 9,9s9,-4.03 9,-9c0,-2.74 -1.23,-5.18 -3.17,-6.83z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_kukan.xml
+++ b/app/src/main/res/layout/fragment_kukan.xml
@@ -386,24 +386,20 @@
             app:layout_constraintStart_toEndOf="@id/image_avg_kph_dot"
             app:layout_constraintEnd_toEndOf="@id/view_area_avg_kph"/>
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/button_start"
-            android:layout_width="72dp"
-            android:layout_height="72dp"
+        <ProgressBar
+            android:id="@+id/progress_on_off"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
             android:layout_marginTop="48dp"
-            android:onLongClick="@{() -> viewModel.onLongClickButtonStart()}"
             app:layout_constraintTop_toBottomOf="@id/view_area_avg_kph"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"/>
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="ON/OFF"
-            android:textColor="@color/colorOnPrimary"
-            app:layout_constraintTop_toBottomOf="@id/button_start"
-            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:background="@drawable/bg_on_off_progress"
+            android:progressDrawable="@drawable/fg_on_off_progress"
+            android:progressTint="@color/lcd_color"
+            android:progressTintMode="@{viewModel.kukanState == KukanState.ON ? Mode.SRC_IN : Mode.DST}"
+            android:progress="@{viewModel.progressOnOff}"
             />
 
         <TextView
@@ -417,14 +413,14 @@
             android:maxLines="30"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/button_start"/>
+            app:layout_constraintTop_toBottomOf="@+id/progress_on_off"/>
 
         <ScrollView
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_margin="5dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/button_start"
+            app:layout_constraintEnd_toStartOf="@id/progress_on_off"
             app:layout_constraintTop_toBottomOf="@id/view_area_avg_kph"
             app:layout_constraintBottom_toBottomOf="parent">
             <TextView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,6 +9,7 @@
     <color name="colorSecondaryVariant">#D6E4E5</color>
 
     <color name="lcd_color">#DA0037</color>
+    <color name="lcd_color_off">#292929</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 </resources>


### PR DESCRIPTION
AndroidのデフォルトのonLongClickでは以下の問題があるためUI含め変更

- デフォルトでは１秒未満のためスマホホルダー等に取り付ける際に意図せずON/OFFとなるケースがある
  - 軽減策として時間の延長
- ロングクリックでON/OFFとなることがわからない
  - タップした瞬間にUIが変化及び、ON/OFFのボタンであることがわかりやすいアイコンを配置